### PR TITLE
Close report form infoWindow on report form submission

### DIFF
--- a/frontend/src/components/map/map.js
+++ b/frontend/src/components/map/map.js
@@ -15,7 +15,6 @@ const {
 const _ = require("lodash");
 
 
-// const { InfoBox } = require("react-google-maps/lib/components/addons/InfoBox");
 const googleMap = require("../../config/keys.js").REACT_APP_GOOGLE_KEY;
 const refs = {};
 
@@ -39,6 +38,12 @@ class Map extends Component {
 
   onMapMounted = (ref) => {
     refs.map = ref;
+  };
+
+  //Setting selectedCoords to null closes the report form on submission
+  handleReportSubmission = (event) => {
+    event.preventDefault();
+    this.setState({ selectedCoords: null });
   };
 
   onMapClick = (coord) => {
@@ -116,6 +121,7 @@ class Map extends Component {
                 <ReportFormContainer
                   lat={this.state.selectedCoords.lat}
                   lng={this.state.selectedCoords.lng}
+                  handleReportSubmission={this.handleReportSubmission}
                 />
               </InfoWindow>
             )}

--- a/frontend/src/components/map/report_form.jsx
+++ b/frontend/src/components/map/report_form.jsx
@@ -12,12 +12,13 @@ class ReportForm extends Component{
         };
 
         this.handleReportInputChange = this.handleReportInputChange.bind(this);
-        this.handleReportSubmission = this.handleReportSubmission.bind(this);
+        this.handleSubmit = this.handleSubmit.bind(this);
     }
 
-    handleReportSubmission = (event) => {
+    handleSubmit = (event) => {
         event.preventDefault();
         this.props.composeReport(this.state);
+        this.props.handleReportSubmission(event);
     };
 
     handleReportInputChange = (event) => {
@@ -35,7 +36,7 @@ class ReportForm extends Component{
                     value={this.state.name}
                     onChange={this.handleReportInputChange}
                 ></input>
-                <button onClick={this.handleReportSubmission}>Submit</button>
+                <button onClick={this.handleSubmit}>Submit</button>
             </div> 
         )
     }


### PR DESCRIPTION
### Summary
When a user submits the report form, the form should close automatically.

### Technical Notes
I spent a lot of time investigating how to utilize the `InfoWindow.close()` function. However, it turned out that the easiest way to solve this problem was to reset the `selectedCoords` in the state. 

This may have some unintended consequences, and it might be worth revisiting this feature in a future iteration. **Also of note:** the app is now re-rendering pretty frequently, which is not an ideal user experience.