### PR TITLE
Only logged in user can create new report

### DIFF
--- a/frontend/src/components/map/map.js
+++ b/frontend/src/components/map/map.js
@@ -105,7 +105,7 @@ class Map extends Component {
             ref={this.onMapMounted}
             center={this.state.center}
           >
-            {this.state.selectedCoords && (
+            {this.props.currentUser && this.state.selectedCoords && (
               <InfoWindow
                 position={{
                   lat: this.state.selectedCoords.lat,

--- a/frontend/src/components/map/map_container.js
+++ b/frontend/src/components/map/map_container.js
@@ -3,11 +3,11 @@ import { fetchReports, fetchPlaceReports, fetchReport, composeReport } from '../
 import Map from './map';
 
 const mapState = state => {
-    // debugger
     return({
-        reports: Object.values(state.reports)
-    })
-}
+        reports: Object.values(state.reports),
+        currentUser: state.session.user
+    });
+};
 
 const mapDispatch = dispatch => {
     return({
@@ -15,7 +15,7 @@ const mapDispatch = dispatch => {
         fetchPlaceReports: placeId => dispatch(fetchPlaceReports(placeId)),
         fetchReport: report => dispatch(fetchReport(report)),
         composeReport: report => dispatch(composeReport(report))
-    })
-}
+    });
+};
 
 export default connect(mapState, mapDispatch)(Map);


### PR DESCRIPTION
### Summary
Now only a logged in user can create a new report.

### Technical Notes
Adds `currentUser` as a slice of state for the map component. The `infoWindow` and `reportFormContainer` are only presented if two conditions are true: there is a current user and there are selected coordinates.

### Issue to Resolve
When a non-authenticated user clicks on a point on the map, the map still re-renders because the `onMapClick` function is still triggered and new coordinates are selected. This problem should be solved in a separate PR.