### PR TITLE
Optimizes map performance, unselects report/report-form on search

### DIFF
--- a/frontend/src/components/map/map.js
+++ b/frontend/src/components/map/map.js
@@ -55,7 +55,10 @@ class Map extends Component {
     let lat = coord.latLng.lat();
     let lng = coord.latLng.lng();
 
-    this.setState({ selectedCoords: { lat: lat, lng: lng } });
+    this.setState({ 
+      selectedCoords: { lat: lat, lng: lng },
+      selectedReport: null
+    });
 
     var geocoder = new google.maps.Geocoder();
 
@@ -145,6 +148,7 @@ class Map extends Component {
                   onClick={() => {
                     this.setState({
                       selectedReport: report,
+                      selectedCoords: null
                     });
                   }}
                   icon={{

--- a/frontend/src/components/map/map.js
+++ b/frontend/src/components/map/map.js
@@ -95,6 +95,8 @@ class Map extends Component {
     const nextCenter = _.get(nextMarkers, "0.position", this.state.center);
 
     this.setState({
+      selectedReport: null,
+      selectedCoords: null,
       center: nextCenter,
       markers: nextMarkers,
     });
@@ -131,7 +133,7 @@ class Map extends Component {
                 />
               </InfoWindow>
             )}
-            {/* Maps existing reports */}
+            {/* Plots existing reports onto the map */}
             {this.props.reports.map((report) => {
               return (
                 <Marker
@@ -160,8 +162,8 @@ class Map extends Component {
                 }}
                 onCloseClick={() => {
                   this.setState({
-                    selectedReport: null,
-                    selectedCoords: null
+                    selectedReport: null
+                    // selectedCoords: null
                   });
                 }}
               >

--- a/frontend/src/components/map/map_container.js
+++ b/frontend/src/components/map/map_container.js
@@ -1,10 +1,11 @@
 import { connect } from 'react-redux';
 import { fetchReports, fetchPlaceReports, fetchReport, composeReport } from '../../actions/report_actions';
+import { selectAllReports } from '../../reducers/selectors';
 import Map from './map';
 
 const mapState = state => {
     return({
-        reports: Object.values(state.reports),
+        reports: selectAllReports(state.reports),
         isAuthenticated: state.session.isAuthenticated,
         currentUser: state.session.user
     });

--- a/frontend/src/reducers/selectors.js
+++ b/frontend/src/reducers/selectors.js
@@ -1,0 +1,1 @@
+export const selectAllReports = reports => Object.values(reports);


### PR DESCRIPTION
### Summary
+ Stores reports in a React `selector` to optimize performance on the map
+ When a user completes a location search request, any currently open reports or report forms close (allowing the map to recenter on the selected search location)
+ If a report form is open and an existing report is clicked, the report form now closes
+ If an existing report is being viewed and a report form is opened, the existing report now closes

### Technical Notes
These changes were made in pursuit of fixing the broader problem of the page re-rendering each time a user clicks on a report. This issue remains unresolved.