### PR TITLE
Adds ability to display minutes/hours since reported

### DIFF
--- a/frontend/src/components/report/report.jsx
+++ b/frontend/src/components/report/report.jsx
@@ -9,13 +9,13 @@ class Report extends Component {
 
     this.state = {
       selectedReport: false,
-      hoursSinceReported: this.hoursSinceReported()
+      minutesSinceReported: this.minutesSinceReported()
     };
 
     this.updateReport = this.updateReport.bind(this);
   }
 
-  hoursSinceReported = () => {
+  minutesSinceReported = () => {
     // Milliseconds elapsed since the UNIX epoch 
     const currentDateTime = Date.now();
     const reportDateTime = Date.parse(this.props.report.date);
@@ -25,9 +25,9 @@ class Report extends Component {
     if (diff < 60) {
       return `${diff} minutes ago`;
     } else if (diff < 120) {
-      return `${Math.floor(diff/60)} hour ago`;
+      return `about ${Math.floor(diff/60)} hour ago`;
     } else if (diff <= 4320) {
-      return `${Math.floor(diff / 60)} hours ago`;
+      return `about ${Math.floor(diff / 60)} hours ago`;
     } else {
       return `over 72 hours ago`
     }
@@ -81,7 +81,7 @@ class Report extends Component {
               Reported by <strong>{report.reporterName}</strong>
             </p>
             <p>
-        Reported <strong>{this.state.hoursSinceReported}</strong>
+              Reported <strong>{this.state.minutesSinceReported}</strong>
             </p>
             <p className="instock-verification">
               <span><strong>In stock? </strong></span><button onClick={this.updateReport}><i className="far fa-thumbs-up"></i></button><button><i className="far fa-thumbs-down"></i></button>

--- a/frontend/src/components/report/report.jsx
+++ b/frontend/src/components/report/report.jsx
@@ -8,14 +8,32 @@ class Report extends Component {
     super(props);
 
     this.state = {
-      selectedReport: false
+      selectedReport: false,
+      hoursSinceReported: this.hoursSinceReported()
     };
 
     this.updateReport = this.updateReport.bind(this);
   }
 
-  updateReport = (e) => {
+  hoursSinceReported = () => {
+    // Milliseconds elapsed since the UNIX epoch 
+    const currentDateTime = Date.now();
+    const reportDateTime = Date.parse(this.props.report.date);
+    // Diff in minutes
+    const diff = Math.floor((currentDateTime - reportDateTime) / 1000 / 60);
 
+    if (diff < 60) {
+      return `${diff} minutes ago`;
+    } else if (diff < 120) {
+      return `${Math.floor(diff/60)} hour ago`;
+    } else if (diff <= 4320) {
+      return `${Math.floor(diff / 60)} hours ago`;
+    } else {
+      return `over 72 hours ago`
+    }
+  };
+
+  updateReport = (e) => {
     e.preventDefault();
     this.props.updateReport({ "id": this.props.report._id });
   };
@@ -31,6 +49,7 @@ class Report extends Component {
             lng: report.lng,
           }}
           onClick={() => {
+            debugger
             this.setState({
               selectedReport: true
             });
@@ -60,6 +79,9 @@ class Report extends Component {
             </p>
             <p>
               Reported by <strong>{report.reporterName}</strong>
+            </p>
+            <p>
+        Reported <strong>{this.state.hoursSinceReported}</strong>
             </p>
             <p className="instock-verification">
               <span><strong>In stock? </strong></span><button onClick={this.updateReport}><i className="far fa-thumbs-up"></i></button><button><i className="far fa-thumbs-down"></i></button>


### PR DESCRIPTION
### Summary
As a user, I should able to decide on the value of a report based on when it was reported. I am able to see this in the description of a store according to the following logic:
+ If the amount of time elapsed is less than an hour, I can see the total number of minutes
+ If the amount of time elapsed is less than two hours, then I see `about an hour ago`
+ If the amount of time elapsed is less than 72 hours ago, then I see `about {x} hours ago`
+ If the amount of time elapsed is more than 72 hours ago, then i see `over 72 hours ago` 