### PR TITLE
Adds ability to filter map by report creation date

### DIFF
--- a/frontend/src/components/map/map.css
+++ b/frontend/src/components/map/map.css
@@ -53,6 +53,16 @@
   top: 100px;
 }
 
+.time-filter-container {
+  position: absolute;
+  top: 220px;
+  right: 10px;
+  display: flex;
+  flex-direction: column;
+  background-color: white;
+  padding: 10px;
+}
+
 /* GEOLOCATION */
 .geolocation-button {
   position: absolute;

--- a/frontend/src/components/map/map.js
+++ b/frontend/src/components/map/map.js
@@ -177,8 +177,8 @@ class Map extends Component {
               const currentDateTime = Date.now();
               const reportDateTime = Date.parse(report.date);
               // millisecondsDiff / 1000 => seconds; seconds / 60 => minutes; minutes / 60 => hours
-              const milliSecondsDiff = Math.floor((currentDateTime - reportDateTime) / 1000 / 60 / 60);
-              if (milliSecondsDiff <= this.state.timeFilter) {
+              const millisecondsDiff = Math.floor((currentDateTime - reportDateTime) / 1000 / 60 / 60);
+              if (millisecondsDiff <= this.state.timeFilter) {
                 return (
                   <ReportContainer
                     key={report._id}

--- a/frontend/src/components/map/map.js
+++ b/frontend/src/components/map/map.js
@@ -142,7 +142,7 @@ class Map extends Component {
               <label htmlFor="time-filter">Filter by date reported</label>
               <select id="time-filter" onChange={this.handleTimeFilter} value={this.state.timeFilter}>
                   <option value="Infinity">All time</option>
-                  <option value="24">Today </option>
+                  <option value="24">Past 24 hours </option>
                   <option value="48">Past 2 days</option>
                   <option value="72">Past 3 days</option>
                   <option value="168">Past week</option>
@@ -173,12 +173,12 @@ class Map extends Component {
             )}
             {/* Plots existing reports onto the map */}
             {this.props.reports.map((report) => {
-              // Milliseconds elapsed since the UNIX epoch 
+              // Milliseconds elapsed since the UNIX epoch represented as integer
               const currentDateTime = Date.now();
               const reportDateTime = Date.parse(report.date);
-              // Diff in hours
-              const diff = Math.floor((currentDateTime - reportDateTime) / 1000 / 60 / 60);
-              if (diff <= this.state.timeFilter) {
+              // millisecondsDiff / 1000 => seconds; seconds / 60 => minutes; minutes / 60 => hours
+              const milliSecondsDiff = Math.floor((currentDateTime - reportDateTime) / 1000 / 60 / 60);
+              if (milliSecondsDiff <= this.state.timeFilter) {
                 return (
                   <ReportContainer
                     key={report._id}

--- a/frontend/src/components/report/report.jsx
+++ b/frontend/src/components/report/report.jsx
@@ -26,10 +26,14 @@ class Report extends Component {
       return `${diff} minutes ago`;
     } else if (diff < 120) {
       return `about ${Math.floor(diff/60)} hour ago`;
-    } else if (diff <= 4320) {
-      return `about ${Math.floor(diff / 60)} hours ago`;
+    } else if (diff < 4320) {
+      return `about ${Math.floor(diff/60)} hours ago`;
+    } else if (diff < 10080) {
+      return `about ${Math.floor(diff/60/24) } days ago`;
+    } else if (diff <= 20160) {
+      return `about ${Math.floor(diff/60/24/7)} weeks ago`;
     } else {
-      return `over 72 hours ago`
+      return `more than two weeks ago`
     }
   };
 

--- a/frontend/src/components/report/report.jsx
+++ b/frontend/src/components/report/report.jsx
@@ -49,7 +49,6 @@ class Report extends Component {
             lng: report.lng,
           }}
           onClick={() => {
-            debugger
             this.setState({
               selectedReport: true
             });

--- a/frontend/src/components/report/report.jsx
+++ b/frontend/src/components/report/report.jsx
@@ -16,22 +16,23 @@ class Report extends Component {
   }
 
   minutesSinceReported = () => {
-    // Milliseconds elapsed since the UNIX epoch 
+    // Milliseconds elapsed since the UNIX epoch represented as integer
     const currentDateTime = Date.now();
     const reportDateTime = Date.parse(this.props.report.date);
-    // Diff in minutes
-    const diff = Math.floor((currentDateTime - reportDateTime) / 1000 / 60);
+    // millisecondsDiff/1000 => seconds; seconds/60 => minutes; 
+    //minutes/60 => hours; hours/24 => days; days/7 => weeks;
+    const millisecondsDiff = Math.floor((currentDateTime - reportDateTime) / 1000 / 60);
 
-    if (diff < 60) {
-      return `${diff} minutes ago`;
-    } else if (diff < 120) {
-      return `about ${Math.floor(diff/60)} hour ago`;
-    } else if (diff < 4320) {
-      return `about ${Math.floor(diff/60)} hours ago`;
-    } else if (diff < 10080) {
-      return `about ${Math.floor(diff/60/24) } days ago`;
-    } else if (diff <= 20160) {
-      return `about ${Math.floor(diff/60/24/7)} weeks ago`;
+    if (millisecondsDiff < 60) {
+      return `${millisecondsDiff} minutes ago`;
+    } else if (millisecondsDiff < 120) {
+      return `about ${Math.floor(millisecondsDiff/60)} hour ago`;
+    } else if (millisecondsDiff < 4320) {
+      return `about ${Math.floor(millisecondsDiff/60)} hours ago`;
+    } else if (millisecondsDiff < 10080) {
+      return `about ${Math.floor(millisecondsDiff/60/24) } days ago`;
+    } else if (millisecondsDiff <= 20160) {
+      return `about ${Math.floor(millisecondsDiff/60/24/7)} weeks ago`;
     } else {
       return `more than two weeks ago`
     }


### PR DESCRIPTION
### Summary
As a user, I should be able to filter InStock location relative to how recently reports were made. By default, the map includes all entries.

A user can select several other options:
+ today
+ past two days
+ past three days
+ past week
+ past two weeks

### Notes
Any report older than a week or two, seems unreliable. We should consider only showing reports that are younger than two weeks old.