### PR TITLE
Create report based on Searchbox results

### DIFF
--- a/frontend/src/components/map/map.css
+++ b/frontend/src/components/map/map.css
@@ -61,6 +61,7 @@
   flex-direction: column;
   background-color: white;
   padding: 10px;
+  box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 4px -1px;
 }
 
 /* GEOLOCATION */

--- a/frontend/src/components/map/map.js
+++ b/frontend/src/components/map/map.js
@@ -79,6 +79,7 @@ class Map extends Component {
         bounds.extend(place.geometry.location);
       }
     });
+
     const nextMarkers = places.map((place) => ({
       position: place.geometry.location,
     }));
@@ -89,11 +90,22 @@ class Map extends Component {
     });
   };
 
-  //Setting selectedVendor to null closes the report form on submission
+  //Set selectedVendor and searchBoxMarkers to null on report form submission
   handleReportSubmission = (e) => {
     e.preventDefault();
-    this.setState({ selectedVendor: null });
+    this.setState({
+      selectedVendor: null,
+      searchBoxMarkers: []
+    });
   };
+
+  //Set selectedVendor and searchBoxMarkers to null on report form close
+  handleReportFormClose = (e) => {
+    this.setState({
+      selectedVendor: null,
+      searchBoxMarkers: []
+    })
+  }
 
   handleTimeFilter = (e) => {
     e.preventDefault();
@@ -124,7 +136,7 @@ class Map extends Component {
             </div>
             <div><i className="fas fa-location-arrow geolocation-button" onClick={this.centerOnGeolocation}></i></div>
             {/* Display the report form on marker of search result if user authenticated */}
-            {this.state.selectedVendor && (
+            {this.props.isAuthenticated && this.state.selectedVendor && (
                 <ReportFormContainer
                   vendorPlaceId={this.state.selectedVendor.place_id}
                   vendorName={this.state.selectedVendor.name}
@@ -134,6 +146,7 @@ class Map extends Component {
                   vendorLat={this.state.selectedVendor.geometry.location.lat()}
                   vendorLng={this.state.selectedVendor.geometry.location.lng()}
                   handleReportSubmission={this.handleReportSubmission}
+                  handleReportFormClose={this.handleReportFormClose}
                 />
             )}
             {/* Plots existing reports onto the map */}

--- a/frontend/src/components/map/map.js
+++ b/frontend/src/components/map/map.js
@@ -66,33 +66,6 @@ class Map extends Component {
     this.setState({ selectedVendor: null });
   };
 
-  //Set selected coords when user clicks on open space of map
-  onMapClick = (coord) => {
-    if (!this.props.isAuthenticated) {
-      return;
-    }
-
-    let lat = coord.latLng.lat();
-    let lng = coord.latLng.lng();
-
-    this.setState({ 
-      selectedCoords: { lat: lat, lng: lng }
-    });
-
-    var geocoder = new google.maps.Geocoder();
-
-    geocoder.geocode({ location: coord.latLng }, function (results, status) {
-      if (status === "OK") {
-        if (results[0]) {
-        } else {
-          window.alert("No results found");
-        }
-      } else {
-        window.alert("Geocoder failed due to: " + status);
-      }
-    });
-  };
-
 
   onSearchBoxMounted = (ref) => {
     refs.searchBox = ref;

--- a/frontend/src/components/map/map.js
+++ b/frontend/src/components/map/map.js
@@ -168,6 +168,13 @@ class Map extends Component {
                 }}
               >
                 <ReportFormContainer
+                  vendorPlaceId={this.state.selectedVendor.place_id}
+                  vendorName={this.state.selectedVendor.name}
+                  vendorAddress={this.state.selectedVendor.formatted_address}
+                  vendorPhone={this.state.selectedVendor.formatted_phone_number}
+                  vendorStatus={this.state.selectedVendor.business_status}
+                  vendorLat={this.state.selectedVendor.geometry.location.lat()}
+                  vendorLng={this.state.selectedVendor.geometry.location.lng()}
                   lat={this.state.selectedVendor.geometry.location.lat()}
                   lng={this.state.selectedVendor.geometry.location.lng()}
                   handleReportSubmission={this.handleReportSubmission}

--- a/frontend/src/components/map/map.js
+++ b/frontend/src/components/map/map.js
@@ -24,11 +24,8 @@ class Map extends Component {
     super(props);
 
     this.state = {
-      selectedCoords: null,
-      reportInputText: "",
       bounds: null,
       center: { lat: 40.672482, lng: -73.968208 },
-      markers: [],
       timeFilter: Infinity,
       selectedVendor: null
     };
@@ -58,13 +55,6 @@ class Map extends Component {
   onMapMounted = (ref) => {
     refs.map = ref;
   };
-
-  //Setting selectedCoords to null closes the report form on submission
-  handleReportSubmission = (event) => {
-    event.preventDefault();
-    this.setState({ selectedVendor: null });
-  };
-
 
   onSearchBoxMounted = (ref) => {
     refs.searchBox = ref;
@@ -135,7 +125,7 @@ class Map extends Component {
                   vendorStatus={this.state.selectedVendor.business_status}
                   vendorLat={this.state.selectedVendor.geometry.location.lat()}
                   vendorLng={this.state.selectedVendor.geometry.location.lng()}
-                  handleReportSubmission={this.handleReportSubmission}
+                  handleReportFormClose={this.handleReportFormClose}
                 />
             )}
             {/* Plots existing reports onto the map */}
@@ -171,10 +161,6 @@ class Map extends Component {
                 className="address-searchbar"
               />
             </SearchBox>
-            {this.state.markers.map((marker, index) => (
-              <Marker key={index} position={marker.position} />
-            ))}
-        
           </GoogleMap>
         );
       })

--- a/frontend/src/components/map/map.js
+++ b/frontend/src/components/map/map.js
@@ -89,6 +89,12 @@ class Map extends Component {
     });
   };
 
+  //Setting selectedVendor to null closes the report form on submission
+  handleReportSubmission = (e) => {
+    e.preventDefault();
+    this.setState({ selectedVendor: null });
+  };
+
   handleTimeFilter = (e) => {
     e.preventDefault();
     this.setState ({
@@ -127,7 +133,7 @@ class Map extends Component {
                   vendorStatus={this.state.selectedVendor.business_status}
                   vendorLat={this.state.selectedVendor.geometry.location.lat()}
                   vendorLng={this.state.selectedVendor.geometry.location.lng()}
-                  handleReportFormClose={this.handleReportFormClose}
+                  handleReportSubmission={this.handleReportSubmission}
                 />
             )}
             {/* Plots existing reports onto the map */}

--- a/frontend/src/components/map/map.js
+++ b/frontend/src/components/map/map.js
@@ -77,7 +77,6 @@ class Map extends Component {
     const bounds = new google.maps.LatLngBounds();
 
     places.forEach((place) => {
-      debugger
       this.setState({
         selectedVendor: place
       });
@@ -109,7 +108,6 @@ class Map extends Component {
         return (
           <GoogleMap
             defaultZoom={15}
-            // onClick={this.onMapClick}
             ref={this.onMapMounted}
             center={this.state.center}
           >
@@ -125,21 +123,8 @@ class Map extends Component {
                 </select>
             </div>
             <div><i className="fas fa-location-arrow geolocation-button" onClick={this.centerOnGeolocation}></i></div>
-            {this.state.selectedVendor && (
-              <InfoWindow
-                
-                position={{
-                  lat: this.state.selectedVendor.geometry.location.lat(),
-                  lng: this.state.selectedVendor.geometry.location.lng(),
-                }}
-                onCloseClick={() => {
-                  this.setState({
-                    selectedVendor: null
-                    // selectedCoords: null,
-                    // reportInputText: ""
-                  });
-                }}
-              >
+            {/* Display the report form on marker of search result if user authenticated */}
+            {this.props.isAuthenticated && this.state.selectedVendor && (
                 <ReportFormContainer
                   vendorPlaceId={this.state.selectedVendor.place_id}
                   vendorName={this.state.selectedVendor.name}
@@ -148,11 +133,8 @@ class Map extends Component {
                   vendorStatus={this.state.selectedVendor.business_status}
                   vendorLat={this.state.selectedVendor.geometry.location.lat()}
                   vendorLng={this.state.selectedVendor.geometry.location.lng()}
-                  lat={this.state.selectedVendor.geometry.location.lat()}
-                  lng={this.state.selectedVendor.geometry.location.lng()}
                   handleReportSubmission={this.handleReportSubmission}
                 />
-              </InfoWindow>
             )}
             {/* Plots existing reports onto the map */}
             {this.props.reports.map((report) => {

--- a/frontend/src/components/map/map.js
+++ b/frontend/src/components/map/map.js
@@ -63,7 +63,7 @@ class Map extends Component {
   //Setting selectedCoords to null closes the report form on submission
   handleReportSubmission = (event) => {
     event.preventDefault();
-    this.setState({ selectedCoords: null });
+    this.setState({ selectedVendor: null });
   };
 
   //Set selected coords when user clicks on open space of map

--- a/frontend/src/components/map/map.js
+++ b/frontend/src/components/map/map.js
@@ -6,7 +6,6 @@ import {
   withGoogleMap,
   GoogleMap,
   Marker,
-  InfoWindow,
 } from "react-google-maps";
 import ReportFormContainer from '../report_form/report_form_container';
 import ReportContainer from '../report/report_container';

--- a/frontend/src/components/map/map.js
+++ b/frontend/src/components/map/map.js
@@ -30,7 +30,8 @@ class Map extends Component {
       bounds: null,
       center: { lat: 40.672482, lng: -73.968208 },
       markers: [],
-      timeFilter: Infinity
+      timeFilter: Infinity,
+      selectedVendor: null
     };
 
     this.centerOnGeolocation = this.centerOnGeolocation.bind(this);
@@ -103,6 +104,10 @@ class Map extends Component {
     const bounds = new google.maps.LatLngBounds();
 
     places.forEach((place) => {
+      debugger
+      this.setState({
+        selectedVendor: place
+      });
       if (place.geometry.viewport) {
         bounds.union(place.geometry.viewport);
       } else {
@@ -113,11 +118,8 @@ class Map extends Component {
       position: place.geometry.location,
     }));
     const nextCenter = _.get(nextMarkers, "0.position", this.state.center);
-
     this.setState({
-      selectedCoords: null,
       center: nextCenter,
-      markers: nextMarkers,
     });
   };
 
@@ -134,7 +136,7 @@ class Map extends Component {
         return (
           <GoogleMap
             defaultZoom={15}
-            onClick={this.onMapClick}
+            // onClick={this.onMapClick}
             ref={this.onMapMounted}
             center={this.state.center}
           >
@@ -150,23 +152,24 @@ class Map extends Component {
                 </select>
             </div>
             <div><i className="fas fa-location-arrow geolocation-button" onClick={this.centerOnGeolocation}></i></div>
-            {this.state.selectedCoords && (
+            {this.state.selectedVendor && (
               <InfoWindow
                 
                 position={{
-                  lat: this.state.selectedCoords.lat,
-                  lng: this.state.selectedCoords.lng,
+                  lat: this.state.selectedVendor.geometry.location.lat(),
+                  lng: this.state.selectedVendor.geometry.location.lng(),
                 }}
                 onCloseClick={() => {
                   this.setState({
-                    selectedCoords: null,
-                    reportInputText: ""
+                    selectedVendor: null
+                    // selectedCoords: null,
+                    // reportInputText: ""
                   });
                 }}
               >
                 <ReportFormContainer
-                  lat={this.state.selectedCoords.lat}
-                  lng={this.state.selectedCoords.lng}
+                  lat={this.state.selectedVendor.geometry.location.lat()}
+                  lng={this.state.selectedVendor.geometry.location.lng()}
                   handleReportSubmission={this.handleReportSubmission}
                 />
               </InfoWindow>

--- a/frontend/src/components/map/map.js
+++ b/frontend/src/components/map/map.js
@@ -27,6 +27,7 @@ class Map extends Component {
       bounds: null,
       center: { lat: 40.672482, lng: -73.968208 },
       timeFilter: Infinity,
+      searchBoxMarkers: [],
       selectedVendor: null
     };
 
@@ -84,6 +85,7 @@ class Map extends Component {
     const nextCenter = _.get(nextMarkers, "0.position", this.state.center);
     this.setState({
       center: nextCenter,
+      searchBoxMarkers: nextMarkers
     });
   };
 
@@ -161,6 +163,10 @@ class Map extends Component {
                 className="address-searchbar"
               />
             </SearchBox>
+            {/* Map markers for results of searchbox search */}
+            {this.state.searchBoxMarkers.map((marker, index) => (
+              <Marker key={index} position={marker.position} />
+            ))}
           </GoogleMap>
         );
       })

--- a/frontend/src/components/map/map.js
+++ b/frontend/src/components/map/map.js
@@ -76,9 +76,12 @@ class Map extends Component {
     const bounds = new google.maps.LatLngBounds();
 
     places.forEach((place) => {
-      this.setState({
-        selectedVendor: place
-      });
+      if (this.props.isAuthenticated) {
+        this.setState({
+          selectedVendor: place
+        });
+      }
+
       if (place.geometry.viewport) {
         bounds.union(place.geometry.viewport);
       } else {
@@ -123,7 +126,7 @@ class Map extends Component {
             </div>
             <div><i className="fas fa-location-arrow geolocation-button" onClick={this.centerOnGeolocation}></i></div>
             {/* Display the report form on marker of search result if user authenticated */}
-            {this.props.isAuthenticated && this.state.selectedVendor && (
+            {this.state.selectedVendor && (
                 <ReportFormContainer
                   vendorPlaceId={this.state.selectedVendor.place_id}
                   vendorName={this.state.selectedVendor.name}

--- a/frontend/src/components/report/report.jsx
+++ b/frontend/src/components/report/report.jsx
@@ -54,7 +54,6 @@ class Report extends Component {
             lng: report.vendorLng,
           }}
           onClick={() => {
-            debugger
             this.setState({
               selectedReport: true
             });

--- a/frontend/src/components/report/report.jsx
+++ b/frontend/src/components/report/report.jsx
@@ -54,6 +54,7 @@ class Report extends Component {
             lng: report.vendorLng,
           }}
           onClick={() => {
+            debugger
             this.setState({
               selectedReport: true
             });

--- a/frontend/src/components/report/report.jsx
+++ b/frontend/src/components/report/report.jsx
@@ -50,8 +50,8 @@ class Report extends Component {
       <>
         <MarkerWithLabel
           position={{
-            lat: report.lat,
-            lng: report.lng,
+            lat: report.vendorLat,
+            lng: report.vendorLng,
           }}
           onClick={() => {
             this.setState({
@@ -65,8 +65,8 @@ class Report extends Component {
         </MarkerWithLabel>
         {this.state.selectedReport && (<InfoWindow
           position={{
-            lat: report.lat,
-            lng: report.lng,
+            lat: report.vendorLat,
+            lng: report.vendorLng,
           }}
           onCloseClick={() => {
             this.setState({
@@ -76,10 +76,13 @@ class Report extends Component {
         >
           <div>
             <h2 className="map-report-name">
-              {report.storeName}
+              {report.vendorName}
             </h2>
-            <p className="map-report-description">
-              {report.description}
+            <p>
+              {report.vendorAddress}
+            </p>
+            <p>
+              {report.vendorPhone}
             </p>
             <p>
               Reported by <strong>{report.reporterName}</strong>

--- a/frontend/src/components/report/report.jsx
+++ b/frontend/src/components/report/report.jsx
@@ -78,12 +78,8 @@ class Report extends Component {
             <h2 className="map-report-name">
               {report.vendorName}
             </h2>
-            <p>
-              {report.vendorAddress}
-            </p>
-            <p>
-              {report.vendorPhone}
-            </p>
+            <p>{report.vendorAddress}</p>
+            <a href={"tel:+1" + report.vendorPhone}>{report.vendorPhone}</a>
             <p>
               Reported by <strong>{report.reporterName}</strong>
             </p>

--- a/frontend/src/components/report_form/report_form.jsx
+++ b/frontend/src/components/report_form/report_form.jsx
@@ -20,10 +20,9 @@ class ReportForm extends Component{
         this.handleReportInputChange = this.handleReportInputChange.bind(this);
     }
 
-    handleSubmit = (event) => {
-        event.preventDefault();
+    handleSubmit = (e) => {
+        e.preventDefault();
         this.props.composeReport(this.state);
-        this.props.handleReportSubmission(event);
     };
 
     //input changes are handled based on "name" of html element

--- a/frontend/src/components/report_form/report_form.jsx
+++ b/frontend/src/components/report_form/report_form.jsx
@@ -17,13 +17,20 @@ class ReportForm extends Component{
         };
         
         this.handleSubmit = this.handleSubmit.bind(this);
+        this.handleClose = this.handleClose.bind(this);
         this.handleReportInputChange = this.handleReportInputChange.bind(this);
     }
 
     handleSubmit = (e) => {
         e.preventDefault();
         this.props.composeReport(this.state);
+        this.props.handleReportSubmission(e);
     };
+
+    handleClose = (e) => {
+        this.props.handleReportFormClose(e);
+    };
+
 
     //input changes are handled based on "name" of html element
     handleReportInputChange = (e) => {
@@ -40,6 +47,8 @@ class ReportForm extends Component{
                     lat: this.state.vendorLat,
                     lng: this.state.vendorLng,
                 }}
+
+                onCloseClick={this.handleClose}
             >
                 <div>
                     <h2>Tell us who's got the TP</h2>

--- a/frontend/src/components/report_form/report_form.jsx
+++ b/frontend/src/components/report_form/report_form.jsx
@@ -16,6 +16,7 @@ class ReportForm extends Component{
         };
         
         this.handleSubmit = this.handleSubmit.bind(this);
+        this.handleReportInputChange = this.handleReportInputChange.bind(this);
     }
 
     handleSubmit = (event) => {
@@ -24,12 +25,22 @@ class ReportForm extends Component{
         this.props.handleReportSubmission(event);
     };
 
+    handleReportInputChange = (event) => {
+        event.preventDefault();
+        this.setState({ vendorName: event.target.value });
+    };
+
     render(){
 
         return(
             <div>
                 <h2>Tell us who's got the TP</h2>
-                <p>{this.props.vendorName}</p>
+                <p>{this.state.vendorName}</p>
+                <input
+                    id="report-text-input"
+                    onChange={this.handleReportInputChange}
+                    placeholder="Edit vendor name"
+                ></input>
                 <p>{this.props.vendorAddress}</p>
                 <a href={"tel:+1" + this.props.vendorPhone}>{this.props.vendorPhone}</a>
                 <p>{this.props.vendorStatus}</p>

--- a/frontend/src/components/report_form/report_form.jsx
+++ b/frontend/src/components/report_form/report_form.jsx
@@ -5,7 +5,6 @@ class ReportForm extends Component{
         super(props);
 
         this.state = {
-            storeName: "",
             reporterId: this.props.currentUser.id,
             reporterName: this.props.currentUser.name,
             vendorPlaceId: this.props.vendorPlaceId,
@@ -15,8 +14,7 @@ class ReportForm extends Component{
             vendorLat: this.props.vendorLat,
             vendorLng: this.props.vendorLng
         };
-
-        this.handleReportInputChange = this.handleReportInputChange.bind(this);
+        
         this.handleSubmit = this.handleSubmit.bind(this);
     }
 
@@ -24,11 +22,6 @@ class ReportForm extends Component{
         event.preventDefault();
         this.props.composeReport(this.state);
         this.props.handleReportSubmission(event);
-    };
-
-    handleReportInputChange = (event) => {
-        event.preventDefault();
-        this.setState({ storeName: event.target.value });
     };
 
     render(){

--- a/frontend/src/components/report_form/report_form.jsx
+++ b/frontend/src/components/report_form/report_form.jsx
@@ -5,11 +5,15 @@ class ReportForm extends Component{
         super(props);
 
         this.state = {
+            storeName: "",
             reporterId: this.props.currentUser.id,
             reporterName: this.props.currentUser.name,
-            storeName: "",
-            lng: this.props.lng,
-            lat: this.props.lat,
+            vendorPlaceId: this.props.vendorPlaceId,
+            vendorName: this.props.vendorName,
+            vendorAddress: this.props.vendorAddress,
+            vendorPhone: this.props.vendorPhone,
+            vendorLat: this.props.vendorLat,
+            vendorLng: this.props.vendorLng
         };
 
         this.handleReportInputChange = this.handleReportInputChange.bind(this);
@@ -32,14 +36,13 @@ class ReportForm extends Component{
         return(
             <div>
                 <h2>Tell us who's got the TP</h2>
-                <input
-                    id="report-text-input"
-                    value={this.state.storeName}
-                    onChange={this.handleReportInputChange}
-                    placeholder="Enter store name"
-                ></input>
-                <button onClick={this.handleSubmit}>Submit</button>
-            </div> 
+                <p>{this.props.vendorName}</p>
+                <p>{this.props.vendorAddress}</p>
+                <a href={"tel:+1" + this.props.vendorPhone}>{this.props.vendorPhone}</a>
+                <p>{this.props.vendorStatus}</p>
+                <p><strong>In stock?</strong></p>
+                <button onClick={this.handleSubmit}>Yup!</button>
+            </div>
         )
     }
 }

--- a/frontend/src/components/report_form/report_form.jsx
+++ b/frontend/src/components/report_form/report_form.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import { InfoWindow } from "react-google-maps";
 
 class ReportForm extends Component{
     constructor(props) {
@@ -25,28 +26,38 @@ class ReportForm extends Component{
         this.props.handleReportSubmission(event);
     };
 
-    handleReportInputChange = (event) => {
-        event.preventDefault();
-        this.setState({ vendorName: event.target.value });
+    //input changes are handled based on "name" of html element
+    handleReportInputChange = (e) => {
+        e.preventDefault();
+        const name = e.target.name;
+        this.setState({[name]: e.target.value });
     };
 
     render(){
-
         return(
-            <div>
-                <h2>Tell us who's got the TP</h2>
-                <p>{this.state.vendorName}</p>
-                <input
-                    id="report-text-input"
-                    onChange={this.handleReportInputChange}
-                    placeholder="Edit vendor name"
-                ></input>
-                <p>{this.props.vendorAddress}</p>
-                <a href={"tel:+1" + this.props.vendorPhone}>{this.props.vendorPhone}</a>
-                <p>{this.props.vendorStatus}</p>
-                <p><strong>In stock?</strong></p>
-                <button onClick={this.handleSubmit}>Yup!</button>
-            </div>
+            <InfoWindow
+
+                position={{
+                    lat: this.state.vendorLat,
+                    lng: this.state.vendorLng,
+                }}
+            >
+                <div>
+                    <h2>Tell us who's got the TP</h2>
+                    <p>{this.state.vendorName}</p>
+                    <input
+                        id="report-text-input"
+                        name="vendorName"
+                        onChange={this.handleReportInputChange}
+                        placeholder="Edit vendor name"
+                    ></input>
+                    <p>{this.state.vendorAddress}</p>
+                    <a href={"tel:+1" + this.state.vendorPhone}>{this.state.vendorPhone}</a>
+                    <p>{this.state.vendorStatus}</p>
+                    <p><strong>In stock?</strong></p>
+                    <button onClick={this.handleSubmit}>Yup!</button>
+                </div>
+            </InfoWindow>
         )
     }
 }

--- a/frontend/src/components/session/signup_form.jsx
+++ b/frontend/src/components/session/signup_form.jsx
@@ -130,8 +130,6 @@ class SignupForm extends React.Component {
     
     if (isValid) {
       this.props.signup(user, this.props.history).then(this.closeModalOnSubmit);
-      debugger
-
     }
 
   }

--- a/models/Report.js
+++ b/models/Report.js
@@ -4,26 +4,30 @@ const Schema = mongoose.Schema;
 const ReportSchema = new Schema({
     reporterId: {
         type: Schema.Types.ObjectId,
-        ref: 'users'
+        ref: 'users',
+        required: true
     },
     reporterName: {
         type: String,
+        required: true
     },
-    placeId: {
+    vendorPlaceId: {
         type: String,
+        required: true
     },
-    storeName: {
+    vendorName: {
         type: String,
         required: true,
     },
-    description: {
+    vendorAddress: {
         type: String,
+        required: true,
     },
-    lng: {
+    vendorLat: {
         type: Number,
         required: true,
     },
-    lat: {
+    vendorLng: {
         type: Number,
         required: true,
     },

--- a/routes/api/reports.js
+++ b/routes/api/reports.js
@@ -22,11 +22,12 @@ router.post('/',
         const newReport = new Report({
             reporterId: req.body.reporterId,
             reporterName: req.body.reporterName,
-            placeId: req.body.placeId,
-            storeName: req.body.storeName,
-            description: req.body.description,
-            lng: req.body.lng,
-            lat: req.body.lat,
+            vendorPlaceId: req.body.vendorPlaceId,
+            vendorName: req.body.vendorName,
+            vendorAddress: req.body.vendorAddress,
+            vendorPhone: req.body.vendorPhone,
+            vendorLat: req.body.vendorLat,
+            vendorLng: req.body.vendorLng,
             approvals: 1,
         });
 

--- a/routes/api/reports.js
+++ b/routes/api/reports.js
@@ -13,11 +13,11 @@ router.get('/test', (req, res) => {
 router.post('/',
     
     (req, res) => {
-        const { errors, isValid } = validateReportInput(req.body);
+        // const { errors, isValid } = validateReportInput(req.body);
         
-        if (!isValid) {
-            return res.status(600).json(errors);
-        }
+        // if (!isValid) {
+        //     return res.status(600).json(errors);
+        // }
 
         const newReport = new Report({
             reporterId: req.body.reporterId,

--- a/validation/reports.js
+++ b/validation/reports.js
@@ -3,11 +3,15 @@ const validText = require('./valid-text');
 
 module.exports = function validateReportInput(data) {
     let errors = {};
-
-    data.placeId = validText(data.placeId) ? data.placeId : '';
-
-   
-
+    // likely do not need these validations because the user does not directly submit them
+    data.reporterId = validText(data.reporterId) ? data.reporterId : '';
+    data.reporterName = validText(data.reporterName) ? data.reporterName : '';
+    data.vendorPlaceId = validText(data.vendorPlaceId) ? data.vendorPlaceId : '';
+    data.vendorName = validText(data.vendorName) ? data.vendorName : '';
+    data.vendorAddress = validText(data.vendorAddress) ? data.vendorAddress : '';
+    data.vendorPhone = validText(data.vendorPhone) ? data.vendorPhone : '';
+    data.vendorLat = validText(data.vendorLat) ? data.vendorLat : '';
+    data.vendorLng = validText(data.vendorLng) ? data.vendorLng : '';
     data.productType = validText(data.productType) ? data.productType : '';
 
     


### PR DESCRIPTION
### Why
A user should be able to confidently map a report to a specific real location with identifiable address, name, phone, etc. Before these changes, every report was created on rough coordinates assigned based on where the user clicked. These coordinates were not necessarily related to a real world vendor.

### What Changed
If a user is logged in and searches in the SearchBox, the marker where that search results lands is converted into a report form. 

The report form includes several important details that are provided by the Google Places API:
+ placeId
+ place name
+ place address
+ place coordinates
+ place phone

In the future, we can plug into that API to push additional data to the map as needed.

### Edge Cases
In some cases, an address searched will not have a name assigned by Google Places, or the returned name is wrong. If this happens, a user may enter their own vendor name for the report.

### Technical Notes
Major changes were made across the stack. The model, controller, and multiple components were altered. It should be trivial to make more of the report form fields editable using the dynamic input submission handler.

Once these changes are submitted, we will need to reset the database @Solomon-T because all the old data will be invalid.