### PR TITLE
Fix mobile view modal

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2,7 +2,6 @@
 
 .icon {
   height: 25%;
-  width: 25%;
 }
 
 .fa-times {

--- a/frontend/src/components/about/about.css
+++ b/frontend/src/components/about/about.css
@@ -21,6 +21,10 @@
 }
 
 @media screen and (max-width: 700px) {
+    #just-the-four-of-us div {
+        margin: 0.5rem;
+    }
+
     .profile-pic {
         height: 50px;
     }

--- a/frontend/src/components/about/about.css
+++ b/frontend/src/components/about/about.css
@@ -4,7 +4,6 @@
 
 .profile-pic {
     height: 100px;
-    width: 100px;
     border-radius: 50%;
     float: left;
 }
@@ -20,3 +19,12 @@
     display: flex;
     flex-direction: column;
 }
+
+@media screen and (max-width: 700px) {
+    .profile-pic {
+        height: 50px;
+    }
+    .profile-text {
+        font-size: 0.75rem;
+    }
+} 

--- a/frontend/src/components/help/help.css
+++ b/frontend/src/components/help/help.css
@@ -1,0 +1,20 @@
+.help-instructions h3 {
+  margin-bottom: 3px;
+}
+
+.help-instructions ul {
+  margin-top: 3px;
+}
+
+@media screen and (max-width: 700px) {
+  .help-instructions {
+    margin: 1.25rem;
+  }
+  .help-instructions h3 {
+    font-size: 1rem;
+  }
+
+  .help-instructions ul {
+    font-size: 0.5rem;
+  }
+}

--- a/frontend/src/components/help/help.css
+++ b/frontend/src/components/help/help.css
@@ -1,3 +1,11 @@
+.help-instructions {
+  margin: 2rem;
+}
+
+.help-instructions > div {
+  margin: 1.5rem 0rem;
+}
+
 .help-instructions h3 {
   margin-bottom: 3px;
 }
@@ -10,11 +18,20 @@
   .help-instructions {
     margin: 1.25rem;
   }
+
+  .help-instructions > div {
+    margin: 2rem 0rem 2rem 0rem;
+  }
+
+  .help-instructions > div:first-child {
+    margin: 1.5rem 0rem 2rem 0rem;
+  }
+
   .help-instructions h3 {
     font-size: 1rem;
   }
 
   .help-instructions ul {
-    font-size: 0.5rem;
+    font-size: 0.75rem;
   }
 }

--- a/frontend/src/components/help/help.jsx
+++ b/frontend/src/components/help/help.jsx
@@ -17,25 +17,31 @@ class help extends React.Component {
         <span className="login-or-signup-message">Instructions</span>
         
         <div className='help-instructions'>
+          <div>
             <h3>To view reports</h3>
-            <ul className='instruction-ul'>
-                <li>Simply click on a tp icon to view the details</li>
-                <li>You can also search for a store to see if it was reported</li>
+            <ul>
+              <li>Simply click on a tp icon to view the details</li>
+              <li>You can also search for a store to see if it was reported</li>
             </ul>
+          </div>
+          <div>
             <h3>To approve/disapprove reports</h3>
             <ul>
-                <li>Log in</li>
-                <li>Open report you want to approve</li>
-                <li>Click on thumbs up to approve or vice versa</li>
+              <li>Log in</li>
+              <li>Open report you want to approve</li>
+              <li>Click on thumbs up to approve or vice versa</li>
             </ul>
+          </div>
+          <div>
             <h3>To create reports</h3>
             <ul>
-                <li>Log in</li>
-                <li>Use the search bar to search for a store you want to report</li>
-                <li>If store isn't reported yet a form will pop up</li>
-                <li>You can edit the name if not accurate</li>
-                <li>Submit report by clicking "Yup"</li>
+              <li>Log in</li>
+              <li>Use the search bar to search for a store you want to report</li>
+              <li>If store isn't reported yet a form will pop up</li>
+              <li>You can edit the name if not accurate</li>
+              <li>Submit report by clicking "Yup"</li>
             </ul>
+          </div>
         </div>
       
       </div>

--- a/frontend/src/components/help/help.jsx
+++ b/frontend/src/components/help/help.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { withRouter } from 'react-router-dom';
-
+import './help.css';
 class help extends React.Component {
   constructor(props) {
     super(props);
@@ -17,19 +17,19 @@ class help extends React.Component {
         <span className="login-or-signup-message">Instructions</span>
         
         <div className='help-instructions'>
-            <h3 className='instruction-h3'>To view reports</h3>
+            <h3>To view reports</h3>
             <ul className='instruction-ul'>
                 <li>Simply click on a tp icon to view the details</li>
                 <li>You can also search for a store to see if it was reported</li>
             </ul>
-            <h3 className='instruction-h3'>To approve/disapprove reports</h3>
-            <ul className='instruction-ul'>
+            <h3>To approve/disapprove reports</h3>
+            <ul>
                 <li>Log in</li>
                 <li>Open report you want to approve</li>
                 <li>Click on thumbs up to approve or vice versa</li>
             </ul>
-            <h3 className='instruction-h3'>To create reports</h3>
-            <ul className='instruction-ul'>
+            <h3>To create reports</h3>
+            <ul>
                 <li>Log in</li>
                 <li>Use the search bar to search for a store you want to report</li>
                 <li>If store isn't reported yet a form will pop up</li>

--- a/frontend/src/components/help/help.jsx
+++ b/frontend/src/components/help/help.jsx
@@ -8,7 +8,7 @@ class help extends React.Component {
 
   render() {
     return (
-        <div id='help-div' className="auth-form-container">
+        <div id='help-div' className="modal-form-container">
         
         <span className="modal-closer-button" onClick={this.props.closeModal}>
           <i className="fas fa-times"></i>

--- a/frontend/src/components/modal/modal.css
+++ b/frontend/src/components/modal/modal.css
@@ -17,7 +17,7 @@
   left: 50%;
   transform: translate(-50%, -50%);
   background: #8CB3DF;
-  height: 618px;
+  height: 75%;
   width: 500px;
   box-shadow: 10px 10px #1D3B97
 }

--- a/frontend/src/components/modal/modal.css
+++ b/frontend/src/components/modal/modal.css
@@ -33,3 +33,9 @@
   cursor: pointer;
   color: black;
 }
+
+@media screen and (max-width: 700px) {
+  .modal-child {
+    width: 300px;
+  }
+} 

--- a/frontend/src/components/modal/modal.css
+++ b/frontend/src/components/modal/modal.css
@@ -5,7 +5,7 @@
   right: 0;
   left: 0;
   background: rgba(0, 0, 0, 0.7);
-  z-index: 10;
+  z-index: 2;
 }
 
 .modal-child {

--- a/frontend/src/components/navbar/navbar.css
+++ b/frontend/src/components/navbar/navbar.css
@@ -123,7 +123,7 @@
     .navbar input:checked ~ #hamitems {
         display: flex; 
         position: relative;
-        z-index: 100;
+        z-index: 1;
     }
 
     .navbar-header {

--- a/frontend/src/components/session/login_form.jsx
+++ b/frontend/src/components/session/login_form.jsx
@@ -104,7 +104,7 @@ class LoginForm extends React.Component {
 
   renderForm() {
     return (
-      <div className="auth-form-container">
+      <div className="modal-form-container">
         <span className="modal-closer-button" onClick={this.props.closeModal}>
           <i className="fas fa-times"></i>
         </span>

--- a/frontend/src/components/session/login_form_container.jsx
+++ b/frontend/src/components/session/login_form_container.jsx
@@ -14,7 +14,7 @@ const mapDispatchToProps = (dispatch) => {
   return {
     login: (user) => dispatch(login(user)),
     otherForm: (
-      <button className="input-button-2" onClick={() => dispatch(openModal("signup"))}>Not an InStock user yet? Sign Up</button>
+      <a href="" onClick={() => dispatch(openModal("signup"))}>Not an InStock user yet? Sign Up</a>
     ),
     closeModal: () => dispatch(closeModal()),
   };

--- a/frontend/src/components/session/session_form.css
+++ b/frontend/src/components/session/session_form.css
@@ -1,4 +1,4 @@
-.auth-form-container {
+.modal-form-container {
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/frontend/src/components/session/session_form.css
+++ b/frontend/src/components/session/session_form.css
@@ -26,14 +26,6 @@
   text-decoration: underline;
 }
 
-h3.instruction-h3 {
-  margin-bottom: 3px;
-}
-
-ul.instruction-ul {
-  margin-top: 3px;
-}
-
 @media screen and (max-width: 700px) {
   .icon {
     height: 20%;

--- a/frontend/src/components/session/session_form.css
+++ b/frontend/src/components/session/session_form.css
@@ -33,3 +33,9 @@ h3.instruction-h3 {
 ul.instruction-ul {
   margin-top: 3px;
 }
+
+@media screen and (max-width: 700px) {
+  .icon {
+    height: 20%;
+  }
+} 

--- a/frontend/src/components/session/signup_form.jsx
+++ b/frontend/src/components/session/signup_form.jsx
@@ -152,7 +152,7 @@ class SignupForm extends React.Component {
 
   renderForm() {
     return (
-      <div className="auth-form-container">
+      <div className="modal-form-container">
         <span className="modal-closer-button" onClick={this.props.closeModal}>
           <i className="fas fa-times"></i>
         </span>

--- a/frontend/src/components/session/signup_form_container.jsx
+++ b/frontend/src/components/session/signup_form_container.jsx
@@ -17,7 +17,7 @@ const mapDispatchToProps = (dispatch) => {
     signup: (user) => dispatch(signup(user)),
     login: (user) => dispatch(login(user)),
     otherForm: (
-      <button className="input-button-2" onClick={() => dispatch(openModal("login"))}>Already an InStock user? Log in</button>
+      <a href="" onClick={() => dispatch(openModal("login"))}>Already an InStock user? Log in</a>
     ),
     closeModal: () => dispatch(closeModal())
   };


### PR DESCRIPTION
### Summary
On smaller screens, the modal was opening behind the hamburger menu and the styling was not designed for those screen sizes. These changes ensure that the modal is layered on top of the hamburger menu and also tightens up the styling for smaller screens.

### Technical Notes
The main change here of note was adjusting the `z-index` of the modal component css relative to the `z-index` of the hamburger menu. Additional changes were made to the css and html of a few of the forms for better readability in the future.