### PR TITLE
Adjust view of modal for landscape view

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -44,3 +44,20 @@
 .input-button-1:hover, .input-button-2:hover {
   background-color: #B5B4D4;
 }
+
+@media screen and (max-width: 700px) {
+  .icon {
+    height: 20%;
+    margin-bottom: 0;
+  }
+
+  .input-button-1, .input-button-2 {
+    font-size: 1.25rem;
+  }
+}
+
+@media screen and (max-width: 700px) and (orientation: landscape) {
+  .icon {
+    display: none;
+  }
+}

--- a/frontend/src/components/footer/footer.css
+++ b/frontend/src/components/footer/footer.css
@@ -24,6 +24,6 @@ footer {
 @media screen and (max-width: 700px) {
   .link {
     font-size: 1rem;
-    margin-bottom: 0.75rem;
+    margin: 1rem 0;
   }
 }

--- a/frontend/src/components/help/help.css
+++ b/frontend/src/components/help/help.css
@@ -1,5 +1,14 @@
 .help-instructions {
   margin: 2rem;
+  width: auto;
+}
+
+.help-instructions header {
+  font-family: 'Nunito', sans-serif;
+  font-weight: 700;
+  font-size: 1.75rem;
+  color: #793AFC;
+  text-decoration: underline;
 }
 
 .help-instructions > div {
@@ -19,8 +28,12 @@
     margin: 1.25rem;
   }
 
+  .help-instructions header {
+    font-size: 1.25rem;
+  }
+
   .help-instructions > div {
-    margin: 2rem 0rem 2rem 0rem;
+    /* margin: 2rem 0rem 2rem 0rem; */
   }
 
   .help-instructions > div:first-child {
@@ -28,10 +41,10 @@
   }
 
   .help-instructions h3 {
-    font-size: 1rem;
+    font-size: 0.75rem;
   }
 
   .help-instructions ul {
-    font-size: 0.75rem;
+    font-size: 0.5rem;
   }
 }

--- a/frontend/src/components/help/help.jsx
+++ b/frontend/src/components/help/help.jsx
@@ -13,10 +13,8 @@ class help extends React.Component {
         <span className="modal-closer-button" onClick={this.props.closeModal}>
           <i className="fas fa-times"></i>
         </span>
-        
-        <span className="login-or-signup-message">Instructions</span>
-        
         <div className='help-instructions'>
+          <header>Instructions</header>
           <div>
             <h3>To view reports</h3>
             <ul>

--- a/frontend/src/components/modal/modal.css
+++ b/frontend/src/components/modal/modal.css
@@ -22,6 +22,17 @@
   box-shadow: 10px 10px #1D3B97
 }
 
+.modal-form-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  height: 100%;
+  width: 100%;
+
+}
+
 .modal-closer-button {
   position: absolute;
   top: 10px;
@@ -34,8 +45,16 @@
   color: black;
 }
 
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 700px) and (orientation: portrait) {
   .modal-child {
-    width: 300px;
+    height: 70%;
+    width: 90%;
+  }
+}
+
+@media screen and (max-width: 700px) and (orientation: landscape) {
+  .modal-child {
+    height: 95%;
+    width: 70%;
   }
 } 

--- a/frontend/src/components/session/session_form.css
+++ b/frontend/src/components/session/session_form.css
@@ -1,14 +1,3 @@
-.modal-form-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  position: absolute;
-  height: 100%;
-  width: 100%;
-
-}
-
 .auth-form {
   height: inherit;
   width: inherit;
@@ -27,7 +16,7 @@
 }
 
 @media screen and (max-width: 700px) {
-  .icon {
-    height: 20%;
+  .login-or-signup-message {
+    font-size: 1.5rem;
   }
 } 


### PR DESCRIPTION
### Summary
Modal looked weird in landscape view on mobile devices. Made a few more adjustments including usage of the media query property `orientation` to set modal height and width for landscape view.

### Notes
Unfortunately, due to limited screen real estate, have to hide the InStock icon in the signup and login forms on landscape view.