### PR TITLE
Fixes bad redirect link

### DIFF
--- a/frontend/src/components/session/login_form_container.jsx
+++ b/frontend/src/components/session/login_form_container.jsx
@@ -14,7 +14,7 @@ const mapDispatchToProps = (dispatch) => {
   return {
     login: (user) => dispatch(login(user)),
     otherForm: (
-      <a href="" onClick={() => dispatch(openModal("signup"))}>Not an InStock user yet? Sign Up</a>
+      <a href="#" onClick={() => dispatch(openModal("signup"))}>Not an InStock user yet? Sign Up</a>
     ),
     closeModal: () => dispatch(closeModal()),
   };

--- a/frontend/src/components/session/signup_form_container.jsx
+++ b/frontend/src/components/session/signup_form_container.jsx
@@ -17,7 +17,7 @@ const mapDispatchToProps = (dispatch) => {
     signup: (user) => dispatch(signup(user)),
     login: (user) => dispatch(login(user)),
     otherForm: (
-      <a href="" onClick={() => dispatch(openModal("login"))}>Already an InStock user? Log in</a>
+      <a href="#" onClick={() => dispatch(openModal("login"))}>Already an InStock user? Log in</a>
     ),
     closeModal: () => dispatch(closeModal())
   };


### PR DESCRIPTION
### Summary
Redirect link was causing the page to re-render because the href was "", but the current url was "#". Fixed by changing the href.

### Technical Notes
A cleaner way might have been to use React Link or maybe prevent default. However, I wasn't clear on how we would make those changes.