### PR TITLE
Second attempt to remove redux logger from prod

### DIFF
--- a/frontend/src/store/store.js
+++ b/frontend/src/store/store.js
@@ -4,7 +4,14 @@ import logger from "redux-logger";
 
 import rootReducer from "../reducers/root_reducer";
 
+let middleware = [];
+if (process.env.NODE_ENV === 'development') {
+  middleware = [...middleware, thunk, logger];
+} else {
+  middleware = [...middleware, thunk];
+}
+
 const configureStore = (preloadedState = {}) =>
-  createStore(rootReducer, preloadedState, applyMiddleware(thunk, logger));
+  createStore(rootReducer, preloadedState, applyMiddleware(...middleware));
 
 export default configureStore;


### PR DESCRIPTION
### Summary
Moving the dependency for redux logger into dev dependencies did not actually resolve the problem. Instead, I needed to update `store.js` itself to only render logger if the user was in the development environment.

### Technical Notes
Used this [blog article](https://reactnativeforyou.com/how-to-remove-logs-of-redux-logger-in-production/) for reference.