### PR TITLE
Move filter below the map on smaller viewports

### DIFF
--- a/frontend/src/components/map/map.css
+++ b/frontend/src/components/map/map.css
@@ -130,9 +130,14 @@
     display: flex;
     flex-direction: row;
     justify-content: center;
+    color: white;
+    font-size: 1.25rem;
+    background-color: #793AFC;
+    padding: 0.75rem;
   }
 
   .time-filter-container-sm select {
-    margin-left: 1rem;
+    margin-left: .25rem;
+    font-size: 1rem;
   }
 }

--- a/frontend/src/components/map/map.css
+++ b/frontend/src/components/map/map.css
@@ -59,6 +59,10 @@
   box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 4px -1px;
 }
 
+.time-filter-container-sm {
+  display: none;
+}
+
 /* GEOLOCATION */
 .geolocation-button {
   position: absolute;
@@ -81,7 +85,7 @@
 }
 
 .fa {
-  line-height: inherit;
+  line-height: 1.5rem;
 }
 /* SEARCHBOX */
 
@@ -120,5 +124,15 @@
 
   .time-filter-container-lg {
     display: none;
+  }
+
+  .time-filter-container-sm {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+  }
+
+  .time-filter-container-sm select {
+    margin-left: 1rem;
   }
 }

--- a/frontend/src/components/map/map.css
+++ b/frontend/src/components/map/map.css
@@ -47,7 +47,7 @@
   top: 100px;
 }
 
-.time-filter-container {
+.time-filter-container-lg {
   position: absolute;
   /* top: 220px; */
   top: 250px;
@@ -80,6 +80,9 @@
   cursor: pointer;
 }
 
+.fa {
+  line-height: inherit;
+}
 /* SEARCHBOX */
 
 .address-searchbar {
@@ -113,5 +116,9 @@
 
   .call-to-action h2 {
     font-size: 0.85rem;
+  }
+
+  .time-filter-container-lg {
+    display: none;
   }
 }

--- a/frontend/src/components/map/map.jsx
+++ b/frontend/src/components/map/map.jsx
@@ -149,7 +149,7 @@ class Map extends Component {
             ref={this.onMapMounted}
             center={this.state.center}
           >
-            <div className="time-filter-container">
+            <div className="time-filter-container-lg">
               <label htmlFor="time-filter">Filter by date reported</label>
               <select id="time-filter" onChange={this.handleTimeFilter} value={this.state.timeFilter}>
                   <option value="Infinity">All time</option>

--- a/frontend/src/components/map/map.jsx
+++ b/frontend/src/components/map/map.jsx
@@ -240,6 +240,17 @@ class Map extends Component {
             mapElement={<div style={{ height: `100%` }} />}
           />
         </div>
+        <div className="time-filter-container-sm">
+          <label htmlFor="time-filter">Filter by date reported</label>
+          <select id="time-filter" onChange={this.handleTimeFilter} value={this.state.timeFilter}>
+            <option value="Infinity">All time</option>
+            <option value="24">Past 24 hours </option>
+            <option value="48">Past 2 days</option>
+            <option value="72">Past 3 days</option>
+            <option value="168">Past week</option>
+            <option value="336">Past two weeks</option>
+          </select>
+        </div>
       {!this.props.isAuthenticated && (
         <section className="call-to-action">
           <h1>Looking for toilet paper in your neighborhood?</h1>


### PR DESCRIPTION
### Summary
When viewing the app on a mobile device or a very narrow desktop browser window, the filter by date reported dropdown was overlaying relevant data for the currently viewed report.

Issue resolved by hiding the dropdown inside the map on smaller viewports while adding an identical dropdown below the map instead.